### PR TITLE
Fix the url of background image in design-section

### DIFF
--- a/css/kasper.css
+++ b/css/kasper.css
@@ -311,7 +311,7 @@ header nav .form i {
   padding-bottom: var(--section-padding);
   height: 600px;
   position: relative;
-  background-image: url('/images/design-features.jpg');
+  background-image: url('images/design-features.jpg');
   background-size: cover;
   display: flex;
   align-items: center;


### PR DESCRIPTION
The URL of the background image was started with "/" that make it does not work on github pages